### PR TITLE
Do not throw an exception when there is no valid git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ project/plugins/project/
 
 # Scala-IDE specific
 .scala_dependencies
+.idea

--- a/promulgate-version/src/main/scala/com/ambiata/promulgate/version/VersionPlugin.scala
+++ b/promulgate-version/src/main/scala/com/ambiata/promulgate/version/VersionPlugin.scala
@@ -9,20 +9,20 @@ import sbt._, Keys._
 
 object VersionPlugin extends Plugin {
   object VersionKeys {
-    lazy val date             = SettingKey[Date]("current build date")
-    lazy val user             = SettingKey[String]("current build user")
-    lazy val machine          = SettingKey[String]("current build machine")
-    lazy val commish          = SettingKey[String]("current git short commit hash")
-    lazy val commit           = SettingKey[String]("current git full commit hash")
+    lazy val date    = SettingKey[Date]("current build date")
+    lazy val user    = SettingKey[String]("current build user")
+    lazy val machine = SettingKey[String]("current build machine")
+    lazy val commish = SettingKey[String]("current git short commit hash")
+    lazy val commit  = SettingKey[String]("current git full commit hash")
   }
 
   def promulgateVersionSettings = Seq[Sett](
-    VersionKeys.date in ThisBuild           :=   VersionPlugin.now,
-    VersionKeys.user in ThisBuild           :=   VersionPlugin.user,
-    VersionKeys.machine in ThisBuild        :=   VersionPlugin.machine,
-    VersionKeys.commish in ThisBuild        <<=  baseDirectory.apply(VersionPlugin.commish),
-    VersionKeys.commit in ThisBuild         <<=  baseDirectory.apply(VersionPlugin.commit),
-    version in ThisBuild        <<=  (version in ThisBuild, VersionKeys.date, VersionKeys.commish).apply((v, d, c) => s"${v}-${VersionPlugin.timestamp(d)}-${c}")
+    VersionKeys.date in ThisBuild    := VersionPlugin.now,
+    VersionKeys.user in ThisBuild    := VersionPlugin.user,
+    VersionKeys.machine in ThisBuild := VersionPlugin.machine,
+    VersionKeys.commish in ThisBuild := VersionPlugin.commish(baseDirectory.value),
+    VersionKeys.commit in ThisBuild  := VersionPlugin.commit(baseDirectory.value),
+    version in ThisBuild             := s"${(version in ThisBuild).value}-${VersionPlugin.timestamp(VersionKeys.date.value)}-${VersionKeys.commish.value}"
   )
 
   def user =
@@ -43,8 +43,20 @@ object VersionPlugin extends Plugin {
   def commit(root: File) =
     gitlog(root, "%H")
 
-  def gitlog(root: File, format: String) =
-    Process(s"git log --pretty=format:${format} -n  1", Some(root)).lines.head
+  def gitlog(root: File, format: String) = {
+    val command = s"git log --pretty=format:${format} -n  1"
+    try {
+      Process(command, Some(root)).lines.head
+    } catch {
+      case e: Throwable =>
+        println(
+          s"""|[promulgate-plugin] The command '$command' failed and promulgate cannot retrieve a suitable commit to create a BuildInfo class.
+              |[promulgate-plugin] Check if git is installed on the command line and if you have a valid git repository.
+           """.stripMargin)
+
+        "no-commit"
+    }
+  }
 
   lazy val now =
     new Date


### PR DESCRIPTION
@markhibberd what I wanted to do, use the sbt stream logger when computing the version is inherently impossible because a setting can not depend on a task. So I resorted to using `println`.